### PR TITLE
Process company and staff images

### DIFF
--- a/backend/src/main/java/com/visitcard/dto/CompanyDto.java
+++ b/backend/src/main/java/com/visitcard/dto/CompanyDto.java
@@ -10,7 +10,8 @@ import java.util.List;
 public class CompanyDto {
     private Long id;
     private String name;
-    private String logoUrl;
+    private String logoUrl;      // Base64 encoded logo for frontend display
     private String description;
     private List<StaffDto> staffList;
+    private String logoFilePath; // File path stored in database (optional, for debugging)
 }

--- a/backend/src/main/java/com/visitcard/dto/StaffDto.java
+++ b/backend/src/main/java/com/visitcard/dto/StaffDto.java
@@ -11,5 +11,6 @@ public class StaffDto {
     private String name;
     private String phoneNumber;
     private String position;
-    private String photoBase64;
+    private String photoBase64; // Base64 encoded photo for frontend display
+    private String photoUrl;    // File path/URL stored in database (optional, for debugging)
 }

--- a/backend/src/main/java/com/visitcard/service/CompanyService.java
+++ b/backend/src/main/java/com/visitcard/service/CompanyService.java
@@ -85,11 +85,18 @@ public class CompanyService {
                 String staffPhotoBase64 = staff.getPhoto();
                 if (staffPhotoBase64 != null && !staffPhotoBase64.isEmpty()) {
                     try {
-                        String savedPath = imageService.saveStaffImage(staffPhotoBase64, id, staff.getName());
-                        staff.setPhoto(savedPath);
-                        System.out.println("Staff photo path set for " + staff.getName() + ": " + savedPath);
+                        // Check if it's base64 data or already a file path
+                        if (isBase64String(staffPhotoBase64)) {
+                            String savedPath = imageService.saveStaffImage(staffPhotoBase64, id, staff.getName());
+                            staff.setPhoto(savedPath);
+                            System.out.println("Staff photo path set for " + staff.getName() + ": " + savedPath);
+                        } else {
+                            // It's already a file path, keep it as is
+                            staff.setPhoto(staffPhotoBase64);
+                            System.out.println("Staff photo path kept for " + staff.getName() + ": " + staffPhotoBase64);
+                        }
                     } catch (Exception e) {
-                        System.out.println("Error saving staff photo for " + staff.getName() + ": " + e.getMessage());
+                        System.out.println("Error processing staff photo for " + staff.getName() + ": " + e.getMessage());
                         staff.setPhoto(null);
                     }
                 }
@@ -106,13 +113,13 @@ public class CompanyService {
         dto.setName(staff.getName());
         dto.setPhoneNumber(staff.getPhoneNumber());
         dto.setPosition(staff.getPosition());
+        dto.setPhotoUrl(staff.getPhoto()); // Set the file path for debugging/reference
+        
         if (staff.getPhoto() != null && !staff.getPhoto().isEmpty()) {
             try {
-                if(staff.getPhoto() == null){
-                    System.out.println("Error: photo is null");
-                }
                 String base64 = imageService.filePathToBase64(staff.getPhoto());
                 dto.setPhotoBase64(base64);
+                System.out.println("Staff photo converted to base64 for " + staff.getName());
             } catch (Exception e) {
                 System.out.println("Error converting staff photo to base64 for " + staff.getName() + ": " + e.getMessage());
                 dto.setPhotoBase64(null);
@@ -131,6 +138,8 @@ public class CompanyService {
         dto.setId(company.getId());
         dto.setName(company.getName());
         dto.setDescription(company.getDescription());
+        dto.setLogoFilePath(company.getLogoUrl()); // Set the file path for debugging/reference
+        
         if (company.getLogoUrl() != null && !company.getLogoUrl().isEmpty()) {
             try {
                 String base64 = imageService.filePathToBase64(company.getLogoUrl());


### PR DESCRIPTION
Refactor image update logic in `CompanyService` and enhance DTOs to correctly handle staff photo updates and provide file path references.

The `updateCompany` method was not correctly distinguishing between a new base64 image string and an existing file path when processing staff photos. This PR adds a check using `isBase64String` to ensure that only new base64 data is processed and saved, while existing file paths are retained. Additionally, DTOs were updated to include the stored file paths for better debugging and clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-1d4e15a5-27eb-4794-8e7e-07677c6ddd57">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1d4e15a5-27eb-4794-8e7e-07677c6ddd57">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

